### PR TITLE
Don't do `stack setup`, just use the system ghc from the image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ binaries:
 	  --volume "$(PWD)"/docker/bin:/root/.local/bin \
 	  --volume "$(PWD)"/docker/stack:/root/.stack \
 	  --volume "$(PWD)"/docker/stack-work:/src/.stack-work \
-	  fpco/stack-build:lts sh -c "cd /src && stack setup && stack install"
+	  fpco/stack-build:lts sh -c "cd /src && stack install --system-ghc"
 
 # Build a runtime image with the built binaries, but no compilation environment
 image:


### PR DESCRIPTION
In addition to solving this problem on my Sierra OSX machine (https://github.com/pbrisbin/haskell-docker-example/issues/3) this avoids a potentially useless step of rebuilding GHC (as the correct GHC seems to be already present in the fpco image)